### PR TITLE
Fixed Command Injection

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -23,7 +23,10 @@ _.sleep = function(ms) {
 
 _.exec = function(cmd, opts) {
   return new Promise((resolve, reject) => {
-    childProcess.exec(cmd, _.merge({
+    cmd = cmd.split(' ');
+    var cmdFile = cmd[0];
+    cmd.shift();
+    childProcess.execFile(cmdFile, cmd, _.merge({
       maxBuffer: 1024 * 512 * 10,
       wrapArgs: false
     }, opts || {}), (err, stdout) => {


### PR DESCRIPTION
### ⚙️ Description *

The vulnerability is caused due to the usage of `child_process`'s `exec()` function which is vulnerable to Command Injection. Replacing the `exec()` function with `execFile()` function will mitigate this vulnerability.

### 💻 Technical Description *

The occurrence of this vulnerability is caused due to the usage of the `exec()` function. So replacing the `exec()` function with `execFile()` is enough to fix the issue.

Here is how it works:

```javascript
cmd = cmd.split(' ');
var cmdFile = cmd[0];
cmd.shift();
childProcess.execFile(cmdFile, cmd, _.merge({
  maxBuffer: 1024 * 512 * 10,
  wrapArgs: false
}, opts || {}), (err, stdout) => {
  if (err) {
    return reject(err);
  }
  resolve(_.trim(stdout));
});
```

`cmd` string is split by spaces into an array. The first element is the binary file to be executed ie: `production/platform-tools/adb`. First element is given to the `execFile()` as the first argument `cmdFile` then the first element of the array `cmd[]` is taken out with `shitf()` to be given as an argument array to `execFile()`.

### 🐛 Proof of Concept (PoC) *

_**Place this file under the `lib` folder of the project (`poc.js`)**_

```javascript
// poc.js
var adb = require("./macaca-adb")
process.env['ANDROID_HOME'] = 'production';
adb.prototype.install("ssss\"; touch HACKED; #", "")
```

### 🔥 Proof of Fix (PoF) *

    $ cd macaca-adb/
    $ npm install
    $ cd lib/
    $ node poc.js

![macaca-adb-fix](https://user-images.githubusercontent.com/26198477/81435244-2a06fb80-9185-11ea-9d86-65f2919eac15.png)

As you can see from the above screenshot, there is no file named `HACKED` being created thus fixing the issue.

**NOTE:** `UnhandledPromiseRejectionWarning: Error: spawn production/platform-tools/adb ENOENT` is caused due to the binary file missing (`production/platform-tools/adb`).

### 👍 User Acceptance Testing (UAT)

The replacement of the `exec()` function with `execFile()` is the only change implemented.
